### PR TITLE
docs: version the README's API-reference links so they resolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Whether you're building new models, comparing existing ones, or diagnosing perfo
 - **[Documentation site](https://text2sql-eval-toolkit.readthedocs.io/)** — the
   guide (installation, the five stages, the data model, benchmarks, models,
   LLM-as-judge, the CLI and configuration) and the
-  [API reference](https://text2sql-eval-toolkit.readthedocs.io/reference/) for
+  [API reference](https://text2sql-eval-toolkit.readthedocs.io/en/latest/reference/) for
   every exported function and class.
 - **[docs/dashboard/](https://github.com/IBM/text2sql-eval-toolkit/tree/main/docs/dashboard)** — the evaluation dashboard: features,
   shareable links, the query index, capability tiers, and deployment.
@@ -239,7 +239,7 @@ agentic.run_pipeline(
 )
 ```
 
-Every exported function and class is documented in the **[API reference](https://text2sql-eval-toolkit.readthedocs.io/reference/)**, generated from the docstrings.
+Every exported function and class is documented in the **[API reference](https://text2sql-eval-toolkit.readthedocs.io/en/latest/reference/)**, generated from the docstrings.
 
 ### Running Experiments
 


### PR DESCRIPTION
The documentation site is live at https://text2sql-eval-toolkit.readthedocs.io/ and complete.

Two links into it from the README are not. Read the Docs serves pages under `/en/<version>/`, and only the root path redirects to a default version — so the bare `/reference/` these links used returns 404.

Checked against the live site rather than reasoned about:

| URL | |
|---|---|
| `/` | 200 |
| `/en/latest/reference/` | 200 |
| `/reference/` | **404** |

Two lines, README only. The `Documentation` entry in `[project.urls]` is already correct and untouched — it points at the root, which redirects.

Worth landing before `v1.4.0` is tagged: the README is what PyPI renders as the project page.